### PR TITLE
419 HTTP Status Code

### DIFF
--- a/intercept.js
+++ b/intercept.js
@@ -114,6 +114,7 @@ function statusCodes(){
         '416': 'Requested Range Not Satisfiable',
         '417': 'Expectation Failed',
         '418': 'I\'m a teapot',
+        '419': 'Authentication Timeout',
         '421': 'Misdirected Request',
         '422': 'Unprocessable Entity',
         '423': 'Locked',


### PR DESCRIPTION
Adding the 419 status code. This is especially useful for Laravel  SPA apps when your session expires because you get back a 419 CSRF Token Mismatch error.